### PR TITLE
Fix compilation issues in Edge unit tests

### DIFF
--- a/QMorphLib/Msg.cpp
+++ b/QMorphLib/Msg.cpp
@@ -6,7 +6,8 @@
 void 
 Msg::error( const std::string& err )
 {
-	std::cout << "Error: " << err << std::endl;
+        lastError = err;
+        std::cout << "Error: " << err << std::endl;
 	/*Frame f = new Frame();
 	MsgDialog errorDialog;
 	Error error = new Error( err );

--- a/QMorphLib/Msg.h
+++ b/QMorphLib/Msg.h
@@ -8,7 +8,8 @@
 class Msg
 {
 public:
-	inline static bool debugMode = true;
+        inline static bool debugMode = true;
+        inline static std::string lastError;  // store last error message
 
 	/** Output an error message and then exit the program. */
 	static void error( const std::string& err );


### PR DESCRIPTION
## Summary
- add `lastError` field to `Msg` and capture errors
- stub Msg namespace in tests for capturing messages
- remove stray comments and duplicate helpers in `TestEdge.cpp`
- introduce minimal dummy element classes for test scaffolding

## Testing
- `g++ -std=c++20 -I QMorphLib -I /usr/include -I /usr/include/gtest UnitTest/TestEdge.cpp -c -o /tmp/TestEdge.o`

------
https://chatgpt.com/codex/tasks/task_e_68591bd79f54832ca03d8141265c2aad