### PR TITLE
Add Msg header for debug control

### DIFF
--- a/UnitTest/TestEdge.cpp
+++ b/UnitTest/TestEdge.cpp
@@ -11,6 +11,7 @@ double expected = M_PI_2; // 90 degrees in radians
 #include "MyVector.h"
 #include "Triangle.h"
 #include "Quad.h"
+#include "Msg.h"
 
 //All tests are working.
 


### PR DESCRIPTION
## Summary
- include `Msg.h` to access `Msg::debugMode`

## Testing
- `apt-get install -y libgtest-dev`
- `g++ -I./QMorphLib -I./UnitTest -I/usr/include/gtest -c UnitTest/TestEdge.cpp -o /tmp/test.o` *(fails: `std::numbers` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593087dfac832cbf21959c5e953307