### PR TITLE
Fix unit tests compile

### DIFF
--- a/QMorphLib/MeshLoader.cpp
+++ b/QMorphLib/MeshLoader.cpp
@@ -7,6 +7,11 @@
 
 #include <fstream>
 
+// Define static member variables
+ArrayList<std::shared_ptr<Triangle>> MeshLoader::triangleList;
+ArrayList<std::shared_ptr<Edge>> MeshLoader::edgeList;
+ArrayList<std::shared_ptr<Node>> MeshLoader::nodeList;
+
 // Trim from start (in place)
 void ltrim( std::string& s )
 {


### PR DESCRIPTION
## Summary
- add DummyElement helper to satisfy abstract Element requirements
- define static MeshLoader members for linking
- forward declare makeEdge helper
- update tests to use DummyElement

## Testing
- `g++ -std=c++20 UnitTest/TestEdge.cpp QMorphLib/*.cpp UnitTest/pch.cpp -I QMorphLib -I UnitTest -pthread -lgtest -lgtest_main -o test_edge`
- `./test_edge` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_68593f551244832ca43fc45dc7caabdc